### PR TITLE
7 patch item

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==5.4.1
-pytest-flask-sqlalchemy==1.0.2
+pytest>=5.4.1
+pytest-flask-sqlalchemy>=1.0.2
 pytest-mock==2.0.0
 pytest-postgresql==2.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=5.4.1
-pytest-flask-sqlalchemy>=1.0.2
+pytest==5.4.1
+pytest-flask-sqlalchemy==1.0.2
 pytest-mock==2.0.0
-pytest-postgresql>=2.3.0
+pytest-postgresql==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,14 @@ flask-marshmallow==0.11.0
 Flask-Migrate==2.5.2
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.1
+hypothesis==5.8.0
 importlib-metadata==1.5.0
 itsdangerous==1.1.0
 Jinja2==2.11.1
 Mako==1.1.2
 MarkupSafe==1.1.1
 marshmallow==3.5.1
+marshmallow-sqlalchemy==0.22.3
 mccabe==0.6.1
 mirakuru==2.2.0
 more-itertools==8.2.0
@@ -29,6 +31,7 @@ pyparsing==2.4.6
 python-dateutil==2.8.1
 python-editor==1.0.4
 six==1.14.0
+sortedcontainers==2.1.0
 SQLAlchemy==1.3.15
 wcwidth==0.1.8
 Werkzeug==1.0.0

--- a/sabelotodo/models.py
+++ b/sabelotodo/models.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import datetime
 from marshmallow import fields, post_load
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
-from sabelotodo import db, ma
+from sabelotodo import db
 
 GMT = datetime.timezone(datetime.timedelta(hours=0))
 

--- a/sabelotodo/models.py
+++ b/sabelotodo/models.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import datetime
 from marshmallow import fields, post_load
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from sabelotodo import db, ma
 
 GMT = datetime.timezone(datetime.timedelta(hours=0))
@@ -23,7 +24,7 @@ class Item(db.Model):
     parent_id: int = db.Column(db.Integer, db.ForeignKey('items.id'))
 
 
-class ItemSchema(ma.SQLAlchemyAutoSchema):
+class ItemSchema(SQLAlchemyAutoSchema):
     class Meta:
         model = Item
         include_fk = True

--- a/sabelotodo/models.py
+++ b/sabelotodo/models.py
@@ -35,9 +35,12 @@ class ItemSchema(ma.SQLAlchemyAutoSchema):
     # The `timezone` argument prevents off-by-a-few-hours
     # errors we were otherwise getting -- I'm unclear on why it needs
     # to be specified, but empirically it works. (lbv)
-    start_date = fields.NaiveDateTime(format="rfc", timezone=GMT)
-    due_date = fields.NaiveDateTime(format="rfc", timezone=GMT)
-    end_date = fields.NaiveDateTime(format="rfc", timezone=GMT)
+    start_date = fields.NaiveDateTime(format="rfc", timezone=GMT,
+            allow_none=True)
+    due_date = fields.NaiveDateTime(format="rfc", timezone=GMT,
+            allow_none=True)
+    end_date = fields.NaiveDateTime(format="rfc", timezone=GMT,
+            allow_none=True)
 
     # Instruct Marshmallow to actually instantiate an Item object when
     # it deserializes using this schema instead of just giving us

--- a/sabelotodo/routes.py
+++ b/sabelotodo/routes.py
@@ -60,15 +60,20 @@ def patch_item(itemid):
 
     if not json_data:
         return "No data provided", 400
+    if "id" in json_data:
+        return "ID numbers shouldn't change", 400
 
     item_data = item_schema.dump(item)
     item_data.update(json_data)
 
     try:
-        print(item_data)
         item_schema.load(item_data)
         for k, v in item_data.items():
             setattr(item, k, v)
+    # We copy the attributes over like this rather than create a new item so
+    # that we're modifying the existing DB row rather than creating a duplicate
+    # one with a new ID.
+
     except ValidationError as v:
         return "JSON provided doesn't match schema when combined with specified item: %s" % v, 400
 
@@ -80,7 +85,6 @@ def patch_item(itemid):
         return "Database error", 500
 
     return item_schema.dumps(item), 200
-
 
 
 if __name__ == '__main__':

--- a/sabelotodo/routes.py
+++ b/sabelotodo/routes.py
@@ -63,15 +63,18 @@ def patch_item(itemid):
     if not json_data:
         return "No data provided", 400
 
+    print(item)
     item_data = asdict(item)
+    print(item_data)
     item_data.update(json_data)
+    print(item_data)
 
     try:
         item_schema.load(item_data)
         for k, v in item_data.items():
             setattr(item, k, v)
-    except ValidationError:
-        return "JSON provided doesn't match schema when combined with specified item", 400
+    except ValidationError as v:
+        return "JSON provided doesn't match schema when combined with specified item: %s" % v, 400
 
     try:
         db.session.commit()

--- a/sabelotodo/routes.py
+++ b/sabelotodo/routes.py
@@ -82,35 +82,6 @@ def patch_item(itemid):
     return item_schema.dumps(item), 200
 
 
-@app.route('/item/<int:itemid>', methods=["PATCH"])
-def patch_item(itemid):
-    item = Item.query.get_or_404(itemid)
-    json_data = request.get_json()
-
-    if not json_data:
-        return "No data provided", 400
-
-    item_data = asdict(item)
-    item_data.update(json_data)
-
-    try:
-        item_schema.load(item_data)
-        for k, v in item_data.items():
-            setattr(item, k, v)
-    except ValidationError:
-        return "JSON provided doesn't match schema when combined with specified item", 400
-
-    try:
-        db.session.commit()
-    except SQLAlchemyError:
-        # TODO: This branch of code is currently untested (lbv)
-        db.session.rollback()
-        return "Database error", 500
-
-    return jsonify(item), 200
-    # TODO: This should use item_schema.dump, but currently this leads to small
-    # discrepancies in date string format that break tests. (lbv 2020-4-2)
-
 
 if __name__ == '__main__':
     app.run()

--- a/sabelotodo/routes.py
+++ b/sabelotodo/routes.py
@@ -76,10 +76,13 @@ def patch_item(itemid):
     try:
         db.session.commit()
     except SQLAlchemyError:
+        # TODO: This branch of code is currently untested (lbv)
         db.session.rollback()
         return "Database error", 500
 
-    return "Something good", 200
+    return jsonify(item), 200
+    # TODO: This should use item_schema.dump, but currently this leads to small
+    # discrepancies in date string format that break tests. (lbv 2020-4-2)
 
 
 if __name__ == '__main__':

--- a/sabelotodo/tests/test_routes.py
+++ b/sabelotodo/tests/test_routes.py
@@ -52,6 +52,7 @@ VALID_OVERWRITE_DATA = [{'name': 'name change only'},
 INVALID_OVERWRITE_DATA = [{'name': None},  # Remove a required field
                           {'name': 'name too long '*100},
                           {'id': None},
+                          {'start_date': 'January 21, 2012'},
                           {'id': 37},  # Primary key should be immutable,
                                        # since we use it as a foreign key
                           {},

--- a/sabelotodo/tests/test_routes.py
+++ b/sabelotodo/tests/test_routes.py
@@ -51,6 +51,9 @@ VALID_OVERWRITE_DATA = [{'name': 'name change only'},
 
 INVALID_OVERWRITE_DATA = [{'name': None},  # Remove a required field
                           {'name': 'name too long '*100},
+                          {'id': None},
+                          {'id': 37},  # Primary key should be immutable,
+                                       # since we use it as a foreign key
                           {},
                           {'done': 'asdf'}]  # Wrong type: string in a boolean field
 

--- a/sabelotodo/tests/test_routes.py
+++ b/sabelotodo/tests/test_routes.py
@@ -50,6 +50,7 @@ VALID_OVERWRITE_DATA = [{'name': 'name change only'},
                         {'order': 12}]
 
 INVALID_OVERWRITE_DATA = [{'name': None},  # Remove a required field
+                          {'name': 'name too long '*100},
                           {},
                           {'done': 'asdf'}]  # Wrong type: string in a boolean field
 
@@ -98,6 +99,7 @@ def test_item_route_with_multiple_items(test_client, _db):
     return_value = test_client.get('/item')
     returned_items = items_schema.loads(return_value.data)
 
+    assert return_value.status_code == 200, "The request succeeds."
     assert returned_items == Item.query.all(), "Returned items match database."
 
 
@@ -113,7 +115,8 @@ def test_get_itemid_route_with_valid_id(test_client, _db, idx):
     return_value = test_client.get('/item/%s' % selection.id)
     returned_item = item_schema.loads(return_value.data)
 
-    assert returned_item == [selection], "We get back the item we expect."
+    assert return_value.status_code == 200, "The request succeeds."
+    assert returned_item == selection, "We get back the item we expect."
 
 
 @pytest.mark.parametrize("idx", range(len(VALID_ITEM_DATA)))

--- a/sabelotodo/tests/test_routes.py
+++ b/sabelotodo/tests/test_routes.py
@@ -1,190 +1,206 @@
-import pytest, sys, datetime
-from flask import json
-from dataclasses import asdict
+import pytest
+import sys
 from itertools import product
 
-from sabelotodo.models import Item
+from sabelotodo.models import Item, ItemSchema
+
+item_schema = ItemSchema()
+items_schema = ItemSchema(many=True)
+
+VALID_ITEM_DATA = [{'name': 'minimal', 'order': 0, 'done': False},
+                   {'name': 'has_start_date', 'order': 1, 'done': False,
+                       'start_date': 'Sun, 06 Nov 94 08:49:37 -0000'},
+                   {'name': 'has_description', 'order': 4, 'done': False,
+                       'description': 'Lorem ipsum dolor sit amet.'},
+                   {'name': 'already_done', 'order': 8, 'done': True}]
+
+ADDITIONAL_VALID_ITEM_DATA = [{'name': 'a',
+                               'order': 57,
+                               'done': True},
+                              {'name': 'a',
+                               'order': 1,
+                               'done': False,
+                               'description': 'Lorem ipsum dolor sit amet',
+                               'start_date': 'Sun, 05 Apr 20 19:22:13 -0000',
+                               'due_date': 'Mon, 09 Nov 81 19:22:13 -0000',
+                               'end_date': 'Sun, 08 Jun 56 19:22:13 -0000'}]
+
+INVALID_ITEM_DATA = [{'name': 'name too long '*100,
+                      'order': 57,
+                      'done': True},
+                     {'name': 'no order number',
+                      'done': False},
+                     {'name': 'unstandardized date format',
+                      'order': 12,
+                      'done': False,
+                      'start_date': 'January 21, 2012'},
+                     {'name': 'extraneous fields',
+                      'order': 12,
+                      'done': False,
+                      'spatula': 'albuquerque'},
+                     {}  # Empty JSON
+                     ]
+
+VALID_OVERWRITE_DATA = [{'name': 'name change only'},
+                        {'name': 'name and doneness', 'done': True},
+                        {'name': 'update that could overwrite a field',
+                         'description': None},
+                        {'name': 'name and date',
+                         'start_date': 'Tue, 08 Nov 94 08:49:37 -0000'},
+                        {'order': 12}]
+
+INVALID_OVERWRITE_DATA = [{'name': None},  # Remove a required field
+                          {},
+                          {'done': 'asdf'}]  # Wrong type: string in a boolean field
 
 
-def test_create_item(_db):
-    """ Verify that database works"""
-    name = 'TestItem'
-    done = True
-    i = Item(name=name, order=0, done=done)
+@pytest.mark.parametrize("data", VALID_ITEM_DATA)
+def test_create_item_from_empty(_db, data):
+    """ An item can be added directly to an empty database. """
+    item = item_schema.load(data)
 
-    _db.session.add(i)
+    before = Item.query.all()
+    _db.session.add(item)
+    _db.session.commit()
+    after = Item.query.all()
+
+    created = [i for i in after if i not in before]
+    assert created == [item], "Only the specified item is created."
+
+
+@pytest.mark.parametrize("data", ADDITIONAL_VALID_ITEM_DATA)
+def test_create_item_from_populated(_db, data):
+    """ An item can be added directly to a populated database. """
+
+    items = items_schema.load(VALID_ITEM_DATA)
+    _db.session.add_all(items)
     _db.session.commit()
 
-    item = Item.query.filter_by(name=name).first()
-    assert i == item
+    item = item_schema.load(data)
 
+    before = Item.query.all()
+    _db.session.add(item)
+    _db.session.commit()
+    after = Item.query.all()
 
-def test_item_route_with_empty_db(test_client, _db):
-    return_value = test_client.get('/item')
-    assert json.loads(return_value.data) == []
+    created = [i for i in after if i not in before]
+
+    assert created == [item], "Only the specified item is created."
 
 
 def test_item_route_with_multiple_items(test_client, _db):
     """ The /item route retrieves all items added. """
 
-    items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True),
-             Item(name="c", order=1, done=False)]
-
+    items = items_schema.load(VALID_ITEM_DATA)
     _db.session.add_all(items)
     _db.session.commit()
 
     return_value = test_client.get('/item')
-    assert json.loads(return_value.data) \
-        == [asdict(i) for i in Item.query.all()]
+    returned_items = items_schema.loads(return_value.data)
+
+    assert returned_items == Item.query.all(), "Returned items match database."
 
 
-@pytest.mark.parametrize("idx", [0, 1, 2])
+@pytest.mark.parametrize("idx", range(len(VALID_ITEM_DATA)))
 def test_get_itemid_route_with_valid_id(test_client, _db, idx):
     """ The /item/<id> route retrieves just the item with the specified ID. """
 
-    items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True),
-             Item(name="c", order=1, done=False)]
-
+    items = items_schema.load(VALID_ITEM_DATA)
     _db.session.add_all(items)
     _db.session.commit()
 
     selection = items[idx]
     return_value = test_client.get('/item/%s' % selection.id)
-    assert json.loads(return_value.data) == asdict(selection)
+    returned_item = item_schema.loads(return_value.data)
+
+    assert returned_item == [selection], "We get back the item we expect."
 
 
-@pytest.mark.parametrize("idx", [0, 1, 2])
+@pytest.mark.parametrize("idx", range(len(VALID_ITEM_DATA)))
 def test_delete_itemid_route_with_valid_id(test_client, _db, idx):
     """ A DELETE request to /item/<id> deletes the item with the
     specified ID. """
 
-    items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True, start_date='2020-01-01 00:00:00'),
-             Item(name="b", order=2, done=True),
-             Item(name="c", order=1, done=False)]
-
+    items = items_schema.load(VALID_ITEM_DATA)
     _db.session.add_all(items)
     _db.session.commit()
 
     selection = items[idx]
     remainder = items[:idx] + items[idx+1:]
     return_value = test_client.delete('/item/%s' % selection.id)
+    returned_item = item_schema.loads(return_value.data)
 
-    # The request succeeds.
-    assert return_value.status_code == 200
+    assert return_value.status_code == 200, "The request succeeds."
+    assert returned_item == selection, "We get back the item we expect."
+    assert Item.query.all() == remainder, \
+        "The remaining items are the ones we expect."
 
-    # The items left in the database are the ones we expect.
-    assert sorted(Item.query.all()) == sorted(remainder)
-
-    # There is no longer an item in the database with the ID of the one we
-    # selected for deletion.
     get_attempt = test_client.get('/item/%s' % selection.id)
-    assert get_attempt.status_code == 404
+    assert get_attempt.status_code == 404, \
+        "Attempting to get the item we deleted by ID fails."
+
 
 @pytest.mark.parametrize("idx, overwrite_dict",
-        product([0, 1, 2],
-            [{'name': 'newname'},
-             {'order': 3},  # An order number that's available
-             {'start_date': datetime.datetime(2020, 1, 1, 0, 0)},
-             {'start_date': None},
-             {'description': None},
-             {'name': 'multiple things',
-              'description': 'here we are doing multiple fields'}
-             ]))
+                         product(range(len(VALID_ITEM_DATA)),
+                                 VALID_OVERWRITE_DATA))
 def test_patch_itemid_route_with_valid_id(test_client, _db, idx, overwrite_dict):
     """ A PATCH request to /item/<id> overwrites the specified
     fields of the item with the specified ID. """
 
-    items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True, start_date='2020-01-01 00:00:00'),
-             Item(name="c", order=1, done=False),
-             Item(name="d", order=5, done=False, description="foo")]
-
+    items = items_schema.load(VALID_ITEM_DATA)
     _db.session.add_all(items)
     _db.session.commit()
 
     selection = items[idx]
     return_value = test_client.patch('/item/%s' % selection.id, json=overwrite_dict)
-    returned_data = return_value.data
-    changed_item = Item.query.filter_by(id=selection.id).first()
-    print(returned_data)
 
-    # The request succeeds.
-    assert return_value.status_code == 200
+    assert return_value.status_code == 200, "The request succeeds."
 
-    # The item in the database has changed in the way we expect.
-    expected_dict = {**asdict(selection), **overwrite_dict}
-    expected_item = Item(**expected_dict)
-    changed_item == expected_item
+    expected_dict = {**item_schema.dump(selection), **overwrite_dict}
+    expected_item = item_schema.load(expected_dict)
+    assert selection == expected_item, \
+        "The selected item changes in the expected way."
 
-    # The returned dictionary matches the changed item in the database
-    # modulo the effects of json encoding.
-    assert json.loads(returned_data) == json.loads(json.dumps(changed_item))
 
 @pytest.mark.parametrize("idx, overwrite_dict",
-        product([0, 1, 2],
-            [{'name': None},  # Remove a required field
-             {'done': 'asdf'}  # Wrong type: string in a boolean field
-             # TODO: When order number uniqueness is implemented, test it here
-             ]))
+                         product(range(len(VALID_ITEM_DATA)), INVALID_OVERWRITE_DATA))
 def test_patch_itemid_route_with_invalid_combinations(test_client, _db, idx, overwrite_dict):
     """ A PATCH request to /item/<id> overwrites the specified
     fields of the item with the specified ID. """
 
-    items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True),
-             Item(name="c", order=1, done=False),
-             Item(name="d", order=5, done=False, description="foo")]
-
+    items = items_schema.load(VALID_ITEM_DATA)
     _db.session.add_all(items)
     _db.session.commit()
 
+    before = Item.query.all()
     selection = items[idx]
     return_value = test_client.patch('/item/%s' % selection.id, json=overwrite_dict)
+    after = Item.query.all()
 
-    # The request fails.
-    assert return_value.status_code == 400
-
-
-# TODO: Test:
-#  - Can erase a field by passing {fieldname: None}
+    assert return_value.status_code == 400, "The request fails."
+    assert before == after, "Nothing changes."
 
 
-@pytest.mark.parametrize("source_dict",
-                         [{'name': 'a',
-                           'order': 57,
-                           'done': True},
-                          {'name': 'a',
-                           'order': 1,
-                           'done': False,
-                           'description': 'Lorem ipsum dolor sit amet',
-                           'start_date': datetime.datetime(2020, 1, 1, 0, 0),
-                           'due_date': datetime.datetime(2020, 3, 1, 0, 0),
-                           'end_date': datetime.datetime(2020, 5, 1, 0, 0)}
-                          ])
-def test_post_item_route_with_valid_input(test_client, _db, source_dict):
+@pytest.mark.parametrize("request_dict", ADDITIONAL_VALID_ITEM_DATA)
+def test_post_item_route_with_valid_input(test_client, _db, request_dict):
     """ A POST request to /item creates an item with properties specified by
     the JSON payload. We specify _db as a fixture even though we don't use
     it so that the database will be torn down after each run. """
 
-    return_value = test_client.post('/item', json=source_dict)
-    returned_data = return_value.data
-    created_item = Item.query.first()
+    items = items_schema.load(VALID_ITEM_DATA)
+    _db.session.add_all(items)
+    _db.session.commit()
 
-    # The request succeeds.
-    assert return_value.status_code == 200
+    before = Item.query.all()
+    return_value = test_client.post('/item', json=request_dict)
+    returned_item = item_schema.loads(return_value.data)
+    after = Item.query.all()
+    created = [i for i in after if i not in before]
 
-    # The returned dictionary matches the created item in the database
-    # modulo the effects of json encoding.
-    assert json.loads(returned_data) == json.loads(json.dumps(created_item))
-
-    # The created item we see in the database has attributes that are a
-    # superset of the originally specified ones (they should go beyond it, for
-    # instance, in containing an ID, and in containing default values for other
-    # things that weren't specified).
-    assert asdict(created_item).items() >= source_dict.items()
+    assert return_value.status_code == 200, "The request succeeds."
+    assert len(created) == 1, "One thing is created."
+    assert returned_item == created[0], \
+        "The return value matches what is created."
 
 
 @pytest.mark.parametrize(
@@ -196,48 +212,30 @@ def test_invalid_itemid(test_client, _db, itemid, method):
     integers or that don't correspond to an item in the database, and
     does so for any of the methods we support. """
 
-    items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True),
-             Item(name="c", order=1, done=False)]
-
+    items = items_schema.load(VALID_ITEM_DATA)
     _db.session.add_all(items)
     _db.session.commit()
 
+    before = Item.query.all()
     return_value = test_client.open(method=method, path='/item/%s' % itemid)
-    assert return_value.status_code == 404
+    after = Item.query.all()
+
+    assert return_value.status_code == 404, "The request fails."
+    assert before == after, "Nothing changes."
 
 
-@pytest.mark.parametrize("source_dict",
-                         [{'name': 'name too long '*100,
-                           'order': 57,
-                           'done': True},
-                          {'name': 'no order number',
-                           'done': False},
-                          {'name': 'unstandardized date format',
-                           'order': 12,
-                           'done': False,
-                           'start_date': 'January 21, 2012'},
-                          {'name': 'extraneous fields',
-                           'order': 12,
-                           'done': False,
-                           'spatula': 'albuquerque'},
-                          {}  # Empty JSON
-                          ])
+@pytest.mark.parametrize("source_dict", INVALID_ITEM_DATA)
 def test_invalid_post(test_client, _db, source_dict):
     """ The /item POST route fails with a 400 if you give it JSON that fails in
     various ways to satisfy the ItemSchema schema in models.py. """
 
-    items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True),
-             Item(name="c", order=1, done=False)]
-
+    items = items_schema.load(VALID_ITEM_DATA)
     _db.session.add_all(items)
     _db.session.commit()
 
+    before = Item.query.all()
     return_value = test_client.post('/item', json=source_dict)
+    after = Item.query.all()
 
-    # The request fails with a 400 error.
-    assert return_value.status_code == 400
-
-    # Nothing is added to the database.
-    assert Item.query.all() == items
+    assert return_value.status_code == 400, "The request fails."
+    assert before == after, "Nothing changes."

--- a/sabelotodo/tests/test_routes.py
+++ b/sabelotodo/tests/test_routes.py
@@ -61,6 +61,7 @@ def test_delete_itemid_route_with_valid_id(test_client, _db, idx):
     specified ID. """
 
     items = [Item(name="a", order=0, done=False),
+             Item(name="b", order=2, done=True, start_date='2020-01-01 00:00:00'),
              Item(name="b", order=2, done=True),
              Item(name="c", order=1, done=False)]
 
@@ -87,6 +88,7 @@ def test_delete_itemid_route_with_valid_id(test_client, _db, idx):
             [{'name': 'newname'},
              {'order': 3},  # An order number that's available
              {'start_date': datetime.datetime(2020, 1, 1, 0, 0)},
+             {'start_date': None},
              {'description': None},
              {'name': 'multiple things',
               'description': 'here we are doing multiple fields'}
@@ -96,7 +98,7 @@ def test_patch_itemid_route_with_valid_id(test_client, _db, idx, overwrite_dict)
     fields of the item with the specified ID. """
 
     items = [Item(name="a", order=0, done=False),
-             Item(name="b", order=2, done=True),
+             Item(name="b", order=2, done=True, start_date='2020-01-01 00:00:00'),
              Item(name="c", order=1, done=False),
              Item(name="d", order=5, done=False, description="foo")]
 
@@ -107,6 +109,7 @@ def test_patch_itemid_route_with_valid_id(test_client, _db, idx, overwrite_dict)
     return_value = test_client.patch('/item/%s' % selection.id, json=overwrite_dict)
     returned_data = return_value.data
     changed_item = Item.query.filter_by(id=selection.id).first()
+    print(returned_data)
 
     # The request succeeds.
     assert return_value.status_code == 200
@@ -123,7 +126,7 @@ def test_patch_itemid_route_with_valid_id(test_client, _db, idx, overwrite_dict)
 @pytest.mark.parametrize("idx, overwrite_dict",
         product([0, 1, 2],
             [{'name': None},  # Remove a required field
-             {'done': 'asdf'} # Wrong type: string in a boolean field
+             {'done': 'asdf'}  # Wrong type: string in a boolean field
              # TODO: When order number uniqueness is implemented, test it here
              ]))
 def test_patch_itemid_route_with_invalid_combinations(test_client, _db, idx, overwrite_dict):


### PR DESCRIPTION
This pull request adds the ability to modify existing items with a PATCH request to /item/<itemid>. If the modified item wouldn't pass validation, or if the modification could change its ID number, the request fails with 400 and the database does not change. Tests cover updates that would delete required columns or insert values of the wrong type, or that present a date in the wrong format.

In the process of hunting down datetime-related errors I've also made some larger-scale changes. Previous versions used several different ways of creating JSON from an Item object, and several different ways of instantiating an Item object from JSON. Now, all such operations happen through `item_schema` and `items_schema` using their various dump and load methods. This ensures everything is getting validated to the same standard and all (de)serialization of datetime objects happens according to the same rules.

It has a weird consequence, which is that creating an item directly through its `Item()` constructor is a bad idea -- no validation occurs when you do that. Instead of `Item(json)` you need to remember to do `item_schema.loads(json)`. Fixing it may require a bunch of work for dumb reasons. LMK how much of a priority you think it is.