### PR TITLE
50 clean up environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-source env/bin/activate
-
-# Environment variables exported here aren't picked up automatically by Flask:
-# they need to be specifically picked up and used in app.py or elsewhere.
-
-export SQLALCHEMY_DATABASE_URI="postgresql:///sabelotodo_dev"
-export SQLALCHEMY_TRACK_MODIFICATIONS=False
-export TEST_DATABASE_URL="postgresql:///test"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 env
+.env
 
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ npm install
 
 ### Environment variables
 
-On a Mac, set the following environment variables, either manually or using
-autoenv.
+On macOS, create a file in the root directory called `.env` with the following lines, filling in your username
+and password. The project `.gitignore` keeps this file from being pushed to the server, so it is a relatively
+safe place for a password. Omit `DB_PASSWORD` if the database is not password-protected.
 ```
 export SQLALCHEMY_DATABASE_URI="postgresql:///sabelotodo_dev"
 export SQLALCHEMY_TRACK_MODIFICATIONS=False
@@ -47,14 +48,15 @@ export DB_DATABASE=sabelotodo_test
 export DB_PASSWORD=<your db password>
 export TEST_DATABASE_URL=postgresql:///sabelotodo_test
 ```
-Omit `DB_PASSWORD` if the database is not password-protected.
-
 On Linux, do not set the `DB_HOST` and `DB_PORT` environment variables. Create
 a superuser as the `DB_USER` which matches the username of the user that runs
 the tests.
 
+To set up the environment variables before running or testing the project, use `source .env`.
+
 ### Using Autoenv
 
+Alternatively, you can execute your `.env` file using a tool called Autoenv.
 The Autoenv tool manages environment variables for the project and
 automatically activates the virtual environment when you enter the project
 directory. It is optional but convenient.
@@ -65,9 +67,11 @@ deactivate
 pip install autoenv==1.0.0
 ```
 Then, add the `export` commands above to a file called `.env`.  Finally, add
-``source `which activate.sh` `` to your .bashrc or other startup file, and
+``source `which activate.sh` `` to your `.bashrc` or other startup file, and
 rerun that file. Now, when you leave and reenter the project directory, the
 virtual environment activates automatically. 
+
+If you do not use Autoenv, 
 
 ### Database setup
 

--- a/README.md
+++ b/README.md
@@ -33,19 +33,40 @@ pip install -r requirements-dev.txt
 npm install
 ```
 
-### Autoenv setup
+### Environment variables
 
-The autoenv tool manages environment variables for the project and
+On a Mac, set the following environment variables, either manually or using
+autoenv.
+```
+export SQLALCHEMY_DATABASE_URI="postgresql:///sabelotodo_dev"
+export SQLALCHEMY_TRACK_MODIFICATIONS=False
+export DB_HOST=localhost
+export DB_PORT=5432
+export DB_USER=<your postgres username>
+export DB_DATABASE=sabelotodo_test
+export DB_PASSWORD=<your db password>
+export TEST_DATABASE_URL=postgresql:///sabelotodo_test
+```
+Omit `DB_PASSWORD` if the database is not password-protected.
+
+On Linux, do not set the `DB_HOST` and `DB_PORT` environment variables. Create
+a superuser as the `DB_USER` which matches the username of the user that runs
+the tests.
+
+### Using Autoenv
+
+The Autoenv tool manages environment variables for the project and
 automatically activates the virtual environment when you enter the project
-directory. Install it *outside* the virtual environment.
+directory. It is optional but convenient.
 
+To use it, install it *outside* the virtual environment.
 ```
 deactivate
 pip install autoenv==1.0.0
 ```
-
-Then, add ``source `which activate.sh` `` to your .bashrc or other startup
-file, and rerun that file. Now, when you leave and reenter the directory, the
+Then, add the `export` commands above to a file called `.env`.  Finally, add
+``source `which activate.sh` `` to your .bashrc or other startup file, and
+rerun that file. Now, when you leave and reenter the project directory, the
 virtual environment activates automatically. 
 
 ### Database setup
@@ -59,20 +80,6 @@ Now set up the tables using Alembic.
 python manage.py db upgrade
 ```
 Rerun this last command after changing the models or checking out a new branch.
-
-For testing, a test database is set up automatically using environment variables. You will need to set the following variables or add them to your `.env` file. Password can be left out if your database is not password protected. See Linux instructions below.
-```
-export DB_HOST=localhost
-export DB_PORT=5432
-export DB_USER=<your postgres username>
-export DB_DATABASE=sabelotodo_test
-export DB_PASSWORD=<your db password>
-export TEST_DATABASE_URL=postgresql:///sabelotodo_test
-```
-
-#### Linux
-For testing:
-Do not set the DB_HOST and DB_PORT env variables. Create a superuser as the DB_USER which matches the username of the user that runs the tests.
 
 ## Usage
 


### PR DESCRIPTION
Remove `.env` file from version control so that it's safe to store a password in it. Provide unified instructions, all in one place, for setting environment variables manually, or for adding entires to `.env` and setting up autoenv. Clarify in README that a manual `source .env` is required unless you are using Autoenv.